### PR TITLE
Check plugin dependencies after all other plugins are loaded. #2

### DIFF
--- a/sensei-post-to-course.php
+++ b/sensei-post-to-course.php
@@ -67,6 +67,8 @@ function run_sensei_post_to_course() {
 	$plugin->run();
 }
 
-if ( Sensei_Post_To_Course_Dependency_Checker::are_plugin_dependencies_met() ) {
-	run_sensei_post_to_course();
-}
+add_action('plugins_loaded', function () {
+	if ( Sensei_Post_To_Course_Dependency_Checker::are_plugin_dependencies_met() ) {
+		run_sensei_post_to_course();
+	}
+});


### PR DESCRIPTION
Fixes #2 

### Changes proposed in this Pull Request

* Initialize the plugin only after other plugins are loaded. This ensures `Sensei_Main` is loaded before this plugin.

### Testing instructions

<!--
If the functionality of this PR is behind a feature flag, please include the
following testing step, using the correct name for the feature flag. (If you
aren't sure, just ignore this step)

* Enable the feature flag: `add_filter( 'sensei_feature_flag_{THE_FLAG_NAME}', '__return_true' );`
-->
Install the plugin and confirm that there is __no__ message saying:
```
Sensei LMS Post to Course Creator requires that the plugin Sensei LMS (minimum version: 1.11.0) is installed and activated.
```

<!-- Add the following only if there are new/updated actions or filters. Please provide a brief description of what they do and any arguments they may take. Be sure to also add the "Hooks" label to this PR. -->
### New/Updated Hooks

* n/a

<!-- Add the following only if there is any code that is being deprecated. Please list the replacement function or hook that should be called instead, if applicable. Be sure to also add the "Deprecation" label to this PR. -->
### Deprecated Code

* n/a

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video
* n/a
