### PR TITLE
Add support for custom post types

### DIFF
--- a/admin/class-sptc-admin.php
+++ b/admin/class-sptc-admin.php
@@ -84,6 +84,19 @@ class Sensei_Post_To_Course_Admin {
 	}
 
 	/**
+	 * Register the stylesheets for the admin area.
+	 *
+	 * @since 1.1.0
+	 */
+	public function enqueue_scripts() {
+		$screen = get_current_screen();
+
+		if ( 'tools_page_sensei-post-to-course' === $screen->id ) {
+			wp_enqueue_script( $this->plugin_name, plugin_dir_url( __FILE__ ) . 'js/sptc-admin.js', array(), $this->version );
+		}
+	}
+
+	/**
 	 * Add "Post to Course Creator" sub-menu under the "Tools" menu.
 	 *
 	 * @since    1.0.0
@@ -135,6 +148,7 @@ class Sensei_Post_To_Course_Admin {
 
 		// Create the course.
 		$course_name = isset( $input['course_name'] ) ? trim( $input['course_name'] ) : '';
+		$post_type   = isset( $input['post_type'] ) ? trim( $input['post_type'] ) : 'post';
 		$category_id = isset( $input['category_id'] ) ? intval( $input['category_id'] ) : -1;
 		$course_id   = $this->create_course( $course_name );
 
@@ -150,7 +164,7 @@ class Sensei_Post_To_Course_Admin {
 		}
 
 		// Create the lessons.
-		$this->create_lessons( $course_id, $category_id );
+		$this->create_lessons( $course_id, $post_type, $category_id );
 
 		add_settings_error(
 			'sptc_settings',
@@ -207,14 +221,16 @@ class Sensei_Post_To_Course_Admin {
 	/**
 	 * Create the lessons.
 	 *
-	 * @since    1.0.0
-	 * @param    int    $course_id       Course ID.
-	 * @param    int    $category_id     Category ID.
+	 * @since 1.0.0
+	 * @param int    $course_id       Course ID.
+	 * @param string $post_type       Post type.
+	 * @param int    $category_id     Category ID.
 	 */
-	private function create_lessons( $course_id, $category_id ) {
+	private function create_lessons( $course_id, $post_type, $category_id ) {
 		$post_args = array(
 			'numberposts' => -1,
 			'order'       => 'ASC',
+			'post_type'   => $post_type,
 		);
 
 		if ( -1 !== $category_id ) {

--- a/admin/js/sptc-admin.js
+++ b/admin/js/sptc-admin.js
@@ -1,0 +1,12 @@
+document.addEventListener( 'DOMContentLoaded', ( event ) => {
+	const category = document.getElementsByClassName( 'sptc-category' );
+	const postType = document.getElementById( 'sptc-post-type' );
+
+	postType.addEventListener( 'change', event => {
+		if ( 'post' === postType.value ) {
+			category[0].style.display = 'flex';
+		} else {
+			category[0].style.display = 'none';
+		}
+	} );
+} );

--- a/admin/partials/sptc-admin-display.php
+++ b/admin/partials/sptc-admin-display.php
@@ -23,7 +23,7 @@
 		?>
 
 		<p class="sptc-description">
-			<?php esc_html_e( 'Use this tool to create a course from all posts or from posts with a specific category.', 'sensei-post-to-course' ) ?>
+			<?php esc_html_e( 'Use this tool to create a course from posts or from a custom post type.', 'sensei-post-to-course' ) ?>
 		</p>
 
 		<div class="sptc-setting">
@@ -34,7 +34,7 @@
 			</div>
 
 			<div class="sptc-setting-value">
-				<input id="course" type="text" name="sptc_settings[course_name]" class="regular-text text-input">
+				<input id="sptc-course" type="text" name="sptc_settings[course_name]" class="regular-text text-input">
 				<p class="sptc-setting-description">
 					<?php esc_html_e( 'A new course with this name will be created.', 'sensei-post-to-course' ); ?>
 				</p>
@@ -42,6 +42,43 @@
 		</div>
 
 		<div class="sptc-setting">
+			<div class="sptc-setting-label">
+				<label for="sptc-post-type">
+					<?php esc_html_e( 'Post Type', 'sensei-post-to-course' ); ?>:
+				</label>
+			</div>
+
+			<div class="sptc-setting-value">
+				<?php
+					$post_types = get_post_types(
+						[
+							'public'   => true,
+							'_builtin' => false,
+						],
+						'objects'
+					);
+
+					echo '<select id="sptc-post-type" name="sptc_settings[post_type]">';
+					echo '<option value="post">' . __( 'Posts', 'sensei-post-to-course' ) . '</option>';
+
+					foreach ( $post_types as $post_type ) {
+						// Don't include Sensei post types.
+						if ( in_array( $post_type->name, [ 'course', 'lesson', 'quiz', 'sensei_message' ] ) ) {
+							continue;
+						}
+
+						echo '<option value="' . esc_attr( $post_type->name ) . '">' . esc_html( $post_type->label ) . '</option>';
+					}
+
+					echo '</select>';
+				?>
+				<p class="sptc-setting-description">
+					<?php esc_html_e( 'Courses will be created from this post type.', 'sensei-post-to-course' ); ?>
+				</p>
+			</div>
+		</div>
+
+		<div class="sptc-setting sptc-category">
 			<div class="sptc-setting-label">
 				<label for="category">
 					<?php esc_html_e( 'Category', 'sensei-post-to-course' ); ?>:

--- a/includes/class-sensei-post-to-course.php
+++ b/includes/class-sensei-post-to-course.php
@@ -142,6 +142,7 @@ class Sensei_Post_To_Course {
 		$plugin_admin = new Sensei_Post_To_Course_Admin( $this->get_plugin_name(), $this->get_version() );
 
 		$this->loader->add_action( 'admin_enqueue_scripts', $plugin_admin, 'enqueue_styles' );
+		$this->loader->add_action( 'admin_enqueue_scripts', $plugin_admin, 'enqueue_scripts' );
 		$this->loader->add_action( 'admin_menu', $plugin_admin, 'register_menu' );
 		$this->loader->add_action( 'admin_init', $plugin_admin, 'register_settings' );
 	}


### PR DESCRIPTION
This PR adds support for creating a course from a custom post type. In the interest of time, I opted to hide the _Category_ dropdown for custom post types. A future change might involve handling custom taxonomies.

Also, because testing infrastructure hasn't been set up for this repo yet, I haven't added any tests.

### Testing Instructions
- Create a few posts. Add content and excerpts and assign categories to some of them. 
- Go to _Tools_ > _Post to Course Creator_.
- Enter a course name. Ensure _Post Type_ is _Posts_ and _Category_ is _None_.
- Click the _Save Changes_ button.
- Ensure a course is created from all your published posts.
- Repeat the above steps, but select a _Category_ this time.
- Ensure a course is created from all your published posts that have the specified category.
- Select a different value for _Post Type_ (I used Jobs from WP Job Manager and created some jobs).
- Ensure the _Category_ dropdown is hidden.
- Click the _Save Changes_ button.
- Ensure a course is created from all posts of the specified post type.

![Screen Shot 2022-03-18 at 4 06 57 PM](https://user-images.githubusercontent.com/1190420/159076189-508d80e9-05c7-4646-91dd-a12b76d395cd.jpg)