### PR TITLE
Don't use category ID for custom post types

### DIFF
--- a/admin/class-sptc-admin.php
+++ b/admin/class-sptc-admin.php
@@ -149,7 +149,7 @@ class Sensei_Post_To_Course_Admin {
 		// Create the course.
 		$course_name = isset( $input['course_name'] ) ? trim( $input['course_name'] ) : '';
 		$post_type   = isset( $input['post_type'] ) ? trim( $input['post_type'] ) : 'post';
-		$category_id = isset( $input['category_id'] ) ? intval( $input['category_id'] ) : -1;
+		$category_id = 'post' === $post_type && isset( $input['category_id'] ) ? intval( $input['category_id'] ) : -1;
 		$course_id   = $this->create_course( $course_name );
 
 		if ( 0 === $course_id ) {


### PR DESCRIPTION
This PR sets the category ID to -1 for custom post types.

### Testing Instructions
- Create a couple of posts with a category.
- Install WPJM and create a few jobs.
- Go to _Tools_ > _Sensei Post to Course Creator_.
- Enter a course name.
- Set _Category_ to something other than _None_.
- Set _Post Type_ to _Jobs_.
- Ensure a new course is created. Each lesson should be a job listing (and not a post with the category you previously selected).