### PR TITLE
Remove Emails from Post Type dropdown

### DIFF
--- a/admin/partials/sptc-admin-display.php
+++ b/admin/partials/sptc-admin-display.php
@@ -63,7 +63,7 @@
 
 					foreach ( $post_types as $post_type ) {
 						// Don't include Sensei post types.
-						if ( in_array( $post_type->name, [ 'course', 'lesson', 'quiz', 'sensei_message' ] ) ) {
+						if ( in_array( $post_type->name, [ 'course', 'lesson', 'quiz', 'sensei_message', 'sensei_email' ] ) ) {
 							continue;
 						}
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "sensei-post-to-course",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}


### PR DESCRIPTION
Remove Emails from Post Type dropdown as I don't think we want to allow that.

_Before_

![Screenshot 2024-01-25 at 10 16 14 AM](https://github.com/Automattic/sensei-post-to-course/assets/1190420/648f9e3d-f5bd-4ccb-a408-9014856b9802)

_After_

![Screenshot 2024-01-25 at 10 15 29 AM](https://github.com/Automattic/sensei-post-to-course/assets/1190420/3bbbe592-e0ac-4a64-8fea-c23a6035e8b9)
